### PR TITLE
Add KAPE Triage Folder Paths for Chainsaw and Hayabusa

### DIFF
--- a/config/chainsaw/Chainsaw_ServiceTampering.yaml
+++ b/config/chainsaw/Chainsaw_ServiceTampering.yaml
@@ -6,6 +6,7 @@ discovery:
     - service_tampering.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - Event ID

--- a/config/chainsaw/chainsaw_accounttampering_config.yaml
+++ b/config/chainsaw/chainsaw_accounttampering_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - account_tampering.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - Event ID

--- a/config/chainsaw/chainsaw_antivirus_config.yaml
+++ b/config/chainsaw/chainsaw_antivirus_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - antivirus.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - EventID

--- a/config/chainsaw/chainsaw_applocker_config.yaml
+++ b/config/chainsaw/chainsaw_applocker_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - applocker.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - Event ID

--- a/config/chainsaw/chainsaw_credentialaccess_config.yaml
+++ b/config/chainsaw/chainsaw_credentialaccess_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - credential_access.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - Event ID

--- a/config/chainsaw/chainsaw_defenseevasion_config.yaml
+++ b/config/chainsaw/chainsaw_defenseevasion_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - defense_evasion.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - Event ID

--- a/config/chainsaw/chainsaw_indicatorremoval_config.yaml
+++ b/config/chainsaw/chainsaw_indicatorremoval_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - indicator_removal.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - detections

--- a/config/chainsaw/chainsaw_lateralmovement_config.yaml
+++ b/config/chainsaw/chainsaw_lateralmovement_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - lateral_movement.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - Event ID

--- a/config/chainsaw/chainsaw_loginattacks_config.yaml
+++ b/config/chainsaw/chainsaw_loginattacks_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - login_attacks.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - Event ID

--- a/config/chainsaw/chainsaw_logtampering_config.yaml
+++ b/config/chainsaw/chainsaw_logtampering_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - log_tampering.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - Event ID

--- a/config/chainsaw/chainsaw_mft_config.yaml
+++ b/config/chainsaw/chainsaw_mft_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - mft.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - detections

--- a/config/chainsaw/chainsaw_microsoftrasvpn_config.yaml
+++ b/config/chainsaw/chainsaw_microsoftrasvpn_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - microsoft_rasvpn_events.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - Event ID

--- a/config/chainsaw/chainsaw_microsoftrdsevents_config.yaml
+++ b/config/chainsaw/chainsaw_microsoftrdsevents_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - microsoft_rds_events.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - Event ID

--- a/config/chainsaw/chainsaw_persistence_config.yaml
+++ b/config/chainsaw/chainsaw_persistence_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - persistence.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - detections

--- a/config/chainsaw/chainsaw_powershell_config.yaml
+++ b/config/chainsaw/chainsaw_powershell_config.yaml
@@ -8,6 +8,7 @@ discovery:
     - powershell_script.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - detections

--- a/config/chainsaw/chainsaw_rdpevents_config.yaml
+++ b/config/chainsaw/chainsaw_rdpevents_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - rdp_events.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - detections

--- a/config/chainsaw/chainsaw_serviceinstallation_config.yaml
+++ b/config/chainsaw/chainsaw_serviceinstallation_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - service_installation.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - detections

--- a/config/chainsaw/chainsaw_sigma_config.yaml
+++ b/config/chainsaw/chainsaw_sigma_config.yaml
@@ -6,6 +6,7 @@ discovery:
     - sigma.csv
   foldername_patterns:
     - chainsaw
+    - EventLogs
   required_headers:
     - timestamp
     - detections

--- a/config/hayabusa/hayabusa_config.yaml
+++ b/config/hayabusa/hayabusa_config.yaml
@@ -7,6 +7,7 @@ discovery:
     - haya
   foldername_patterns:
     - haya
+    - EventLogs
   required_headers:
     - Timestamp
     - RuleTitle


### PR DESCRIPTION
This allows ForensicTimeliner to be used on KAPE processed outputs for both Chainsaw and Hayabusa without having to move them into different folders. Both Chainsaw and Hayabusa have KAPE modules that when run output to the EventLogs folder. 